### PR TITLE
Add missing dependency on the requests package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -9,7 +9,7 @@ setup(
     version='0.9',
     packages=find_packages(),
     py_modules=['python_markdown_gh_emoji'],
-    install_requires=['markdown>=3.4', 'aiohttp'],
+    install_requires=['markdown>=3.4', 'aiohttp', 'requests'],
     python_requires='>3.10',
     url='https://github.com/edam-software/github_emojis',
     license="OSI Approved :: GNU General Public License v3 or later (GPLv3+)",


### PR DESCRIPTION
When using your extension in a project, installing is not possible if the `requests` module is not present because it is an unspecified dependency of your module.

Adding it to the list of dependency ensures that it gets installed alongside your module when we pip install.


```
    from python_markdown_gh_emoji import GheEmoji
  File "/home/tina/Repositories/Tina/tajine/.venv/lib/python3.10/site-packages/python_markdown_gh_emoji.py", line 4, in <module>
    import requests
ModuleNotFoundError: No module named 'requests'
```